### PR TITLE
fix: 한국시간 기준으로 default `date`, `time` 설정

### DIFF
--- a/korail2/korail2.py
+++ b/korail2/korail2.py
@@ -13,7 +13,6 @@ import sys
 from datetime import datetime, timedelta
 from six import with_metaclass
 from pprint import pprint
-from datetime import timezone
 
 try:
     # noinspection PyPackageRequirements
@@ -736,12 +735,12 @@ There are 4 types of Passengers now, AdultPassenger, ChildPassenger, ToddlerPass
     ...
 
 """
-        # NOTE: 버그 수정. 코레일에 열차 티켓 리스트 API 요청시 한국시간을 기준으로 함.
-        kst = timezone(timedelta(hours=9))
+        # 코레일에 열차 티켓 리스트 API 요청시 한국시간을 기준으로 함.
+        kst_now = datetime.utcnow() + timedelta(hours=9)
         if date is None:
-            date = datetime.utcnow().astimezone(kst).strftime("%Y%m%d")
+            date = kst_now.strftime("%Y%m%d")
         if time is None:
-            time = datetime.utcnow().astimezone(kst).strftime("%H%M%S")
+            time = kst_now.strftime("%H%M%S")
 
         if passengers is None:
             passengers = [AdultPassenger()]


### PR DESCRIPTION
## Summary
- search_train 메서드의 파라미터 `date`, `time`의 디폴트 값 지정에 대한 버그 수정
## What has Changed
- default `date`, `time`를 어느 timezone의 서버든지, 한국시간 기준으로 설정하게끔 변경
## How to test
```python
session = Korail('your-id', 'your-pw')
trains = session.search_train('광명', '천안아산')
# Note: 현재 한국시간 기준으로 다음 열차 출발시각이 출력되는지 확인
print(trains[0])
```